### PR TITLE
Add error handling for invalid data in dumps

### DIFF
--- a/propertysuggester/parser/CsvWriter.py
+++ b/propertysuggester/parser/CsvWriter.py
@@ -1,4 +1,5 @@
 import csv
+import logging
 
 from propertysuggester.utils.datamodel import Entity
 
@@ -26,6 +27,12 @@ def write_row(csv_writer, title, typ, snak):
     @param snak: Snak
     @return:
     """
-    row = (title, typ, snak.property_id, snak.datatype.encode("utf-8"), snak.value.encode("utf-8"))
-    csv_writer.writerow(row)
+    try:
+        row = (title, typ, snak.property_id, snak.datatype.encode("utf-8"), snak.value.encode("utf-8"))
+    except AttributeError, e:
+        logging.warning("attribute error, skip writing %s" % title)
+        row = None
+
+    if row is not None:
+        csv_writer.writerow(row)
 


### PR DESCRIPTION
For things like mismatching datatype / datavalue, or missing datatype (e.g. delete property?) or other corrupt data which I have in my local dev wiki.

These entries can simply be skipped, in my opinion.

The error handling could probably be made nicer than this, but at least this allows the script to finish running and produce a csv when there are errors in a json dump.